### PR TITLE
Fix devfile registry image

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,13 +7,14 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash wget git && pip install yq
+RUN apk add --no-cache py-pip jq bash wget git skopeo && pip install yq
 
 # Registry, organization, and tag to use for base images in dockerfiles. Devfiles
 # will be rewritten during build to use these values for base images.
 ARG PATCHED_IMAGES_REG="quay.io"
 ARG PATCHED_IMAGES_ORG="eclipse"
 ARG PATCHED_IMAGES_TAG="nightly"
+ARG USE_DIGESTS=false
 
 COPY ./build/scripts ./arbitrary-users-patch/base_images /build/
 COPY ./devfiles /build/devfiles
@@ -23,14 +24,16 @@ RUN TAG=${PATCHED_IMAGES_TAG} \
     REGISTRY=${PATCHED_IMAGES_REG} \
     ./update_devfile_patched_image_tags.sh
 RUN ./check_mandatory_fields.sh devfiles
+RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh devfiles; fi
 RUN ./index.sh > /build/devfiles/index.json
 RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles
 
 FROM registry.centos.org/centos/httpd-24-centos7 AS registry
-RUN mkdir /var/www/html/devfiles
+RUN mkdir -m 777 /var/www/html/devfiles
 COPY .htaccess README.md /var/www/html/
 COPY --from=builder /build/devfiles /var/www/html/devfiles
+COPY ./images /var/www/html/images
 COPY ./build/dockerfiles/entrypoint.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["/usr/bin/run-httpd"]

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+LOG_FILE="/tmp/image_digests.log"
+
+function handle_error() {
+  the_image="$1"
+  echo "  Could not read image metadata through skopeo inspect; skip $the_image"
+  echo -n "  Reason: "
+  sed 's|^|    |g' $LOG_FILE
+}
+
+readarray -d '' devfiles < <(find "$1" -name 'devfile.yaml' -print0)
+for image in $(yq -r '.components[]?.image' "${devfiles[@]}" | grep -v "null" | sort | uniq); do
+  digest="$(skopeo inspect "docker://${image}" 2>"$LOG_FILE" | jq -r '.Digest')"
+  if [[ ${digest} ]]; then
+    echo "    $digest # ${image}"
+  else 
+    # for other build methods or for falling back to other registries when not found, can apply transforms here
+    if [[ -x "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh" ]]; then
+      # since extension file may not exist, disable this check
+      # shellcheck disable=SC1090
+      source "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh"
+    fi
+  fi
+
+  # don't rewrite if we couldn't get a digest from either the basic image or the alternative image
+  if [[ ! ${digest} ]]; then
+    handle_error "$image"
+    continue
+  fi
+
+  digest_image="${image%:*}@${digest}"
+
+  # Rewrite images to use sha-256 digests
+  sed -i -E 's|"?'"${image}"'"?|"'"${digest_image}"'" # tag: '"${image}"'|g' "${devfiles[@]}"
+done
+rm $LOG_FILE

--- a/images/codewind.svg
+++ b/images/codewind.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 141.84 141.84">
+    <defs>
+        <style>
+            .cls-1 {
+                fill: #0083ca;
+            }
+        </style>
+    </defs>
+    <title>Codewind_blue</title>
+    <g id="Layer_2" data-name="Layer 2">
+        <g id="Layer_1-2" data-name="Layer 1">
+            <path class="cls-1"
+                d="M82.77,80.16l19.88,30-18.2,18.2Zm-5.65,55.48-6.2,6.2L0,70.92,70.92,0l27,27L78,54.57l6.13,12.21,18.46-35.16,39.3,39.3-34.4,34.4L93.83,76.75l-11.2-.39-.21-6.11h-2ZM72.35,69.15l-49.12,1.5L18.6,75.28l46.13,5.2Z" />
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
This PR updates the Kabanero devfile registry image to fix the permissions on the devfiles folder, when used in CodeReady Workspaces 2.1

### What issues does this PR fix or reference?
